### PR TITLE
feature:hydrate - Allows for property hydration on any class with matching prop names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _A modern PHP JSON Object Serialization Library._
 ## 💖 Support This Project
 This project is supported by your donations! Click the **[Sponsor](https://github.com/sponsors/s-mcdonald)** link to display funding options.
 
-
+___
 
 
 This library enables the Serializing of PHP Objects/Classes. It also contains utility features for working with JSON structures.
@@ -107,43 +107,6 @@ class User implements JsonSerializable
 }
 ```
 
-## Deserialize (Object Hydration)
-This feature is currently in development gives the ability to deserialize back to an object.
-As long as the class you want to instantiate implements JsonSerializable interface, and the JSON property is mapped to the PHP property, you can instantiate any class from any JSON.
-
-By default Json will only serialize values, if you want to deserialize (HYDRATE) the Json back to an object you need to pass `deserialize: true` in the attribute.
-
-```json
-{
-    "name": "foo",
-    "phoneNumbers": [
-      "123456"
-    ]
-}
-```
-```php
-$originalClass = new OriginalClass();
-
-$json = Json::serialize($origalClass);
-$object = Json::deserialize($json, NewClassType::class);
-```
-The JsonProperty attribute has additional arguments to handle
-deserialization targets.
-
-```php
-class NewClassType implements JsonSerializable
-{
-    // Only this property will be loaded from JSON.
-    #[JsonProperty(deserialize: true)]
-    public string $name;
-
-    #[JsonProperty]
-    public array $phoneNumbers;    
-   
-}
-```
-The `NewClassType` will instantiate the object without `$phoneNumbers` being set.
-
 
 ## Promoted Constructor property attributes
 Json allows for attributes on the promoted properties.
@@ -197,6 +160,38 @@ class ChildClass implements JsonSerializable
     "child": {
         "childProp": "bar"
     }
+}
+```
+
+## Deserialize (Object Hydration)
+For simple Hydration, you do not need to implement any attributes or have a mapping for properties, as long as the Class you use has the same properties within your json, PHPJson will hydrate your class or entity.
+
+```json
+{
+  "name": "Freddy",
+  "age": 35,
+  "isActive": true
+}
+```
+```php
+$myUser = Json::deserialize($json, MyUser::class);
+```
+```
+YourNamespace\MyUser Object (
+    'name' => 'Freddy'
+    'age' => 35
+    'isActive' => true
+)
+```
+
+The JsonProperty attribute has additional arguments to handle
+deserialization targets. This will allow you to map to a field with a different property name.
+
+```php
+class NewClassType 
+{
+    #[JsonProperty('name')]
+    public string $userName;
 }
 ```
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -6,10 +6,8 @@ namespace SamMcDonald\Json;
 
 use SamMcDonald\Json\Builder\JsonBuilder;
 use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
-use SamMcDonald\Json\Serializer\Encoding\JsonDecoder;
 use SamMcDonald\Json\Serializer\Enums\JsonFormat;
 use SamMcDonald\Json\Serializer\JsonSerializer;
-use stdClass;
 
 final class Json
 {
@@ -24,15 +22,9 @@ final class Json
         return (new JsonSerializer())->serialize($object, $format);
     }
 
-    // @todo: WIP
-    public static function deserialize(string $json, string $classFqn): stdClass
+    public static function deserialize(string $json, string $classFqn): mixed
     {
-        // @todo: create the decoder - for now use basic decoder
-        return (new JsonDecoder())->decode($json, $classFqn);
-        // Step 1 - Ensure $classFqn is valid type
-        // Step 2 - create a map
-        // Step 3 - decode to stdClass
-        // Step 4 - invoke/ move data to new entity.
+        return (new JsonSerializer())->deserialize($json, $classFqn);
     }
 
     public static function createJsonBuilder(): JsonBuilder

--- a/src/Serializer/Encoding/Contracts/DecoderInterface.php
+++ b/src/Serializer/Encoding/Contracts/DecoderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamMcDonald\Json\Serializer\Encoding\Contracts;
+
+interface DecoderInterface
+{
+    public function decode(string $jsonValue, string $fqClassName): DecodingResultInterface;
+}

--- a/src/Serializer/Encoding/Contracts/DecodingResultInterface.php
+++ b/src/Serializer/Encoding/Contracts/DecodingResultInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamMcDonald\Json\Serializer\Encoding\Contracts;
+
+interface DecodingResultInterface extends EncodingResultInterface
+{
+}

--- a/src/Serializer/Encoding/JsonDecoder.php
+++ b/src/Serializer/Encoding/JsonDecoder.php
@@ -4,18 +4,38 @@ declare(strict_types=1);
 
 namespace SamMcDonald\Json\Serializer\Encoding;
 
-use stdClass;
+use Exception;
+use SamMcDonald\Json\Serializer\Encoding\Contracts\DecodingResultInterface;
+use SamMcDonald\Json\Serializer\Hydrator;
 
-readonly class JsonDecoder
+readonly class JsonDecoder implements Contracts\DecoderInterface
 {
     public function __construct(
+        private Hydrator $hydrator,
         private int $depth = 512,
     ) {
     }
 
-    // @todo: WIP
-    public function decode(string $jsonValue, string $fqClassName): stdClass
+    public function decode(string $jsonValue, string|null $fqClassName = null): DecodingResultInterface
     {
-        return json_decode($jsonValue, false, $this->depth, JSON_FORCE_OBJECT);
+        try {
+            $decodedData = json_decode($jsonValue, false, $this->depth, JSON_THROW_ON_ERROR);
+
+            if (null !== $fqClassName) {
+                $decodedData = $this->hydrator->hydrate($decodedData, $fqClassName);
+            }
+        } catch (Exception $e) {
+            return new JsonDecodingResult(
+                '',
+                $e->getMessage(),
+                false,
+            );
+        }
+
+        return new JsonDecodingResult(
+            $decodedData,
+            $fqClassName ?? '',
+            true,
+        );
     }
 }

--- a/src/Serializer/Encoding/JsonDecodingResult.php
+++ b/src/Serializer/Encoding/JsonDecodingResult.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamMcDonald\Json\Serializer\Encoding;
+
+use SamMcDonald\Json\Serializer\Encoding\Contracts\DecodingResultInterface;
+
+class JsonDecodingResult implements DecodingResultInterface
+{
+    public function __construct(
+        protected mixed $body,
+        protected string $message = '',
+        protected bool $isValid = false,
+    ) {
+    }
+
+    final public function getBody(): mixed
+    {
+        return $this->body;
+    }
+
+    final public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    final public function isValid(): bool
+    {
+        return $this->isValid;
+    }
+}

--- a/src/Serializer/Hydrator.php
+++ b/src/Serializer/Hydrator.php
@@ -4,7 +4,35 @@ declare(strict_types=1);
 
 namespace SamMcDonald\Json\Serializer;
 
+use InvalidArgumentException;
+use ReflectionClass;
+use ReflectionException;
+
 final class Hydrator
 {
-    //
+    public function __construct()
+    {
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function hydrate(object|array $data, string $fqClassName): object
+    {
+        if (!class_exists($fqClassName)) {
+            throw new InvalidArgumentException("The class '$fqClassName' does not exist.");
+        }
+
+        $reflectionClass = new ReflectionClass($fqClassName);
+        $instance = $reflectionClass->newInstanceWithoutConstructor();
+
+        foreach ($data as $key => $value) {
+            if ($reflectionClass->hasProperty($key)) {
+                $property = $reflectionClass->getProperty($key);
+                $property->setValue($instance, $value);
+            }
+        }
+
+        return $instance;
+    }
 }

--- a/src/Serializer/JsonSerializer.php
+++ b/src/Serializer/JsonSerializer.php
@@ -6,7 +6,9 @@ namespace SamMcDonald\Json\Serializer;
 
 use SamMcDonald\Json\Serializer\Attributes\AttributeReader\JsonPropertyReader;
 use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
+use SamMcDonald\Json\Serializer\Encoding\Contracts\DecoderInterface;
 use SamMcDonald\Json\Serializer\Encoding\Contracts\EncoderInterface;
+use SamMcDonald\Json\Serializer\Encoding\JsonDecoder;
 use SamMcDonald\Json\Serializer\Encoding\JsonEncoder;
 use SamMcDonald\Json\Serializer\Encoding\Validator\JsonValidator;
 use SamMcDonald\Json\Serializer\Enums\JsonFormat;
@@ -16,10 +18,15 @@ class JsonSerializer
 {
     public function __construct(
         private EncoderInterface|null $encoder = null,
+        private DecoderInterface|null $decoder = null,
         private ObjectNormalizer|null $objectNormalizer = null,
     ) {
         if (null === $this->encoder) {
             $this->encoder = new JsonEncoder(new JsonValidator());
+        }
+
+        if (null === $this->decoder) {
+            $this->decoder = new JsonDecoder(new Hydrator());
         }
 
         if (null === $this->objectNormalizer) {
@@ -32,5 +39,10 @@ class JsonSerializer
         $jsonBuilder = $this->objectNormalizer->normalize($object);
 
         return $this->encoder->encode($jsonBuilder->toStdClass(), $format)->getBody();
+    }
+
+    public function deserialize(string $json, string $classFqn)
+    {
+        return $this->decoder->decode($json, $classFqn)->getBody();
     }
 }

--- a/tests/Unit/Encoding/DecodingTest.php
+++ b/tests/Unit/Encoding/DecodingTest.php
@@ -17,7 +17,7 @@ class DecodingTest extends TestCase
         $deserializedObject = Json::deserialize($json, ClassWithPublicStringProperty::class);
 
         static::assertInstanceOf(
-            stdClass::class,
+            ClassWithPublicStringProperty::class,
             $deserializedObject,
         );
 

--- a/tests/Unit/Serializer/Fixtures/NoAttributeClasses/SimpleScalaProperties.php
+++ b/tests/Unit/Serializer/Fixtures/NoAttributeClasses/SimpleScalaProperties.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SamMcDonald\Json\Tests\Unit\Serializer\Fixtures\NoAttributeClasses;
+
+use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
+
+class SimpleScalaProperties implements JsonSerializable
+{
+    public string $name;
+    public int $age;
+    public bool $isActive;
+}

--- a/tests/Unit/Serializer/SerializerTest.php
+++ b/tests/Unit/Serializer/SerializerTest.php
@@ -14,6 +14,7 @@ use SamMcDonald\Json\Tests\Unit\Serializer\Fixtures\ClassWithPublicStringPropert
 use SamMcDonald\Json\Tests\Unit\Serializer\Fixtures\GoodChildObjectSerializable;
 use SamMcDonald\Json\Tests\Unit\Serializer\Fixtures\NestingClasses\Nestable;
 use SamMcDonald\Json\Tests\Unit\Serializer\Fixtures\NestingClasses\NestableWithArray;
+use SamMcDonald\Json\Tests\Unit\Serializer\Fixtures\NoAttributeClasses\SimpleScalaProperties;
 use SamMcDonald\Json\Tests\Unit\Serializer\Fixtures\ParentClassSerializable;
 
 class SerializerTest extends TestCase
@@ -252,6 +253,28 @@ JSON
         static::assertEquals(
             $expectedJson,
             Json::serialize($sut, JsonFormat::Pretty),
+        );
+    }
+
+    public function testSimpleHydration(): void
+    {
+        $expected = new SimpleScalaProperties();
+        $expected->name = 'Freddy';
+        $expected->age = 35;
+        $expected->isActive = true;
+
+        $json = <<<JSON
+{
+  "name": "Freddy", 
+  "age": 35, 
+  "isActive": true
+}
+JSON
+            ;
+
+        static::assertEquals(
+            $expected,
+            Json::deserialize($json, SimpleScalaProperties::class),
         );
     }
 }


### PR DESCRIPTION


## Deserialize (Object Hydration)
For simple Hydration, you do not need to implement any attributes or have a mapping for properties, as long as the Class you use has the same properties within your json, PHPJson will hydrate your class or entity.

### PHP
```php
class MyUser 
{
    public string $name;
    public int $age;
    public bool $isActive;
}
```

### JSON
```json
{
  "name": "Freddy",
  "age": 35,
  "isActive": true
}
```
### JSON
```php
$myUser = Json::deserialize($json, MyUser::class);
```
```
YourNamespace\MyUser Object (
    'name' => 'Freddy'
    'age' => 35
    'isActive' => true
)
```

The JsonProperty attribute has additional arguments to handle
deserialization targets. This will allow you to map to a field with a different property name.

```php
class MyUser 
{
    #[JsonProperty('name')]
    public string $userName;

    public int $age;
    public bool $isActive;
}
```