### PR TITLE
maintenance: remove json serializable m1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ echo Json::serialize($user);
 $serializer = new JsonSerializer();
 echo $serializer->serialize($user);
 
-class User implements JsonSerializable
+class User
 {
     #[JsonProperty]
     public string $name;
@@ -75,7 +75,7 @@ class User implements JsonSerializable
 You can override the property or method names by supplying your own. This also works in reverse for hydration.
 
 ```php
-class User implements JsonSerializable
+class User
 {
     #[JsonProperty('userName')]
     public string $name;
@@ -98,7 +98,7 @@ class User implements JsonSerializable
 
 Example using methods
 ```php
-class User implements JsonSerializable
+class User
 {
     #[JsonProperty('creditCardNumber')]
     public function getCreditCard(): int
@@ -126,7 +126,7 @@ $sut->someChild = new ChildClass("bar");
 ```
 
 ```php
-class ParentClass implements JsonSerializable
+class ParentClass
 {
     #[JsonProperty('userName')]
     public string $name;
@@ -135,7 +135,7 @@ class ParentClass implements JsonSerializable
     public ChildClass $someChild;
 }
 
-class ChildClass implements JsonSerializable
+class ChildClass
 {
     public function __construct(
         #[JsonProperty('childProp')]

--- a/src/Builder/AbstractJsonBuilder.php
+++ b/src/Builder/AbstractJsonBuilder.php
@@ -6,11 +6,10 @@ namespace SamMcDonald\Json\Builder;
 
 use Exception;
 use InvalidArgumentException;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 use SamMcDonald\Json\Serializer\Exceptions\JsonException;
 use stdClass;
 
-abstract class AbstractJsonBuilder implements JsonSerializable
+abstract class AbstractJsonBuilder
 {
     private array $jsonProperties = [];
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SamMcDonald\Json;
 
 use SamMcDonald\Json\Builder\JsonBuilder;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 use SamMcDonald\Json\Serializer\Enums\JsonFormat;
 use SamMcDonald\Json\Serializer\Formatter\JsonFormatter;
 use SamMcDonald\Json\Serializer\JsonSerializer;
@@ -21,7 +20,7 @@ final class Json
     }
 
     public static function serialize(
-        JsonSerializable $object,
+        object $object,
         JsonFormat $format = JsonFormat::Compressed,
     ): string {
         return (new JsonSerializer())->serialize($object, $format);

--- a/src/Serializer/Contracts/JsonEnum.php
+++ b/src/Serializer/Contracts/JsonEnum.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace SamMcDonald\Json\Serializer\Contracts;
 
-interface JsonEnum extends JsonSerializable
+interface JsonEnum
 {
 }

--- a/src/Serializer/Contracts/JsonSerializable.php
+++ b/src/Serializer/Contracts/JsonSerializable.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace SamMcDonald\Json\Serializer\Contracts;
 
+/**
+ * @deprecated
+ */
 interface JsonSerializable
 {
 }

--- a/src/Serializer/JsonSerializer.php
+++ b/src/Serializer/JsonSerializer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SamMcDonald\Json\Serializer;
 
 use SamMcDonald\Json\Serializer\Attributes\AttributeReader\JsonPropertyReader;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 use SamMcDonald\Json\Serializer\Encoding\Contracts\DecoderInterface;
 use SamMcDonald\Json\Serializer\Encoding\Contracts\EncoderInterface;
 use SamMcDonald\Json\Serializer\Encoding\JsonDecoder;
@@ -34,7 +33,7 @@ class JsonSerializer
         }
     }
 
-    public function serialize(JsonSerializable $object, JsonFormat $format): string
+    public function serialize(object $object, JsonFormat $format): string
     {
         return $this->encoder->encode($this->objectNormalizer->normalize($object), $format)->getBody();
     }

--- a/src/Serializer/Normalization/Normalizers/ArrayNormalizer.php
+++ b/src/Serializer/Normalization/Normalizers/ArrayNormalizer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SamMcDonald\Json\Serializer\Normalization\Normalizers;
 
 use SamMcDonald\Json\Builder\JsonBuilder;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 use SamMcDonald\Json\Serializer\Exceptions\JsonSerializableException;
 use stdClass;
 
@@ -60,7 +59,7 @@ class ArrayNormalizer
             return true;
         }
 
-        if ($propertyValue instanceof JsonSerializable) {
+        if (is_object($propertyValue)) {
             return true;
         }
 

--- a/src/Serializer/Normalization/Normalizers/Context/Context.php
+++ b/src/Serializer/Normalization/Normalizers/Context/Context.php
@@ -7,13 +7,12 @@ namespace SamMcDonald\Json\Serializer\Normalization\Normalizers\Context;
 use ReflectionMethod;
 use ReflectionProperty;
 use SamMcDonald\Json\Builder\JsonBuilder;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 
 readonly class Context
 {
     public function __construct(
         private ReflectionProperty|ReflectionMethod $reflectionItem,
-        private JsonSerializable $originalObject,
+        private object $originalObject,
         private JsonBuilder $classObject,
         private array $jsonPropertyAttributes,
         private string $propertyName,
@@ -30,7 +29,7 @@ readonly class Context
         return $this->reflectionItem;
     }
 
-    public function getOriginalObject(): JsonSerializable
+    public function getOriginalObject(): object
     {
         return $this->originalObject;
     }

--- a/src/Serializer/Normalization/Normalizers/Context/ContextBuilder.php
+++ b/src/Serializer/Normalization/Normalizers/Context/ContextBuilder.php
@@ -9,7 +9,6 @@ use ReflectionProperty;
 use SamMcDonald\Json\Builder\JsonBuilder;
 use SamMcDonald\Json\Serializer\Attributes\AttributeReader\JsonPropertyReader;
 use SamMcDonald\Json\Serializer\Attributes\JsonProperty;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 
 readonly class ContextBuilder
 {
@@ -20,7 +19,7 @@ readonly class ContextBuilder
 
     public function build(
         ReflectionProperty|ReflectionMethod $prop,
-        JsonSerializable $originalObject,
+        object $originalObject,
         JsonBuilder $classObject,
     ): Context {
         $jsonPropertyAttributes = $prop->getAttributes(JsonProperty::class);

--- a/src/Serializer/Normalization/Normalizers/ObjectNormalizer.php
+++ b/src/Serializer/Normalization/Normalizers/ObjectNormalizer.php
@@ -15,7 +15,6 @@ use SamMcDonald\Json\Builder\JsonBuilder;
 use SamMcDonald\Json\Serializer\Attributes\AttributeReader\JsonPropertyReader;
 use SamMcDonald\Json\Serializer\Attributes\JsonProperty;
 use SamMcDonald\Json\Serializer\Contracts\JsonEnum;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 use SamMcDonald\Json\Serializer\Exceptions\JsonSerializableException;
 use SamMcDonald\Json\Serializer\Normalization\Normalizers\Context\Context;
 use SamMcDonald\Json\Serializer\Normalization\Normalizers\Context\ContextBuilder;
@@ -32,7 +31,7 @@ final readonly class ObjectNormalizer
     ) {
     }
 
-    public function normalize(JsonSerializable $propertyValue): stdClass
+    public function normalize(object $propertyValue): stdClass
     {
         if ($propertyValue instanceof JsonEnum) {
             return $this->normalizeEnum($propertyValue);
@@ -41,7 +40,7 @@ final readonly class ObjectNormalizer
         return $this->transferToJsonBuilder($propertyValue)->toStdClass();
     }
 
-    private function transferToJsonBuilder(JsonSerializable $propertyValue): JsonBuilder
+    private function transferToJsonBuilder(object $propertyValue): JsonBuilder
     {
         $jsonBuilder = new JsonBuilder();
         $contextBuilder = new ContextBuilder($this->propertyReader);
@@ -119,7 +118,7 @@ final readonly class ObjectNormalizer
 
     private function assignToStdClass($propertyName, $propertyValue, JsonBuilder $classObject): void
     {
-        if ($propertyValue instanceof JsonSerializable) {
+        if (is_object($propertyValue)) {
             $classObject->addProperty($propertyName, $this->transferToJsonBuilder($propertyValue));
 
             return;
@@ -135,7 +134,7 @@ final readonly class ObjectNormalizer
     /**
      * @return array<ReflectionProperty>
      */
-    private function getReflectionProperties(JsonSerializable $originalObject): array
+    private function getReflectionProperties(object $originalObject): array
     {
         return (new ReflectionObject($originalObject))->getProperties(
             ReflectionProperty::IS_PUBLIC |
@@ -147,7 +146,7 @@ final readonly class ObjectNormalizer
     /**
      * @return array<ReflectionMethod>
      */
-    private function getReflectionMethods(JsonSerializable $originalObject): array
+    private function getReflectionMethods(object $originalObject): array
     {
         return (new ReflectionObject($originalObject))->getMethods(
             ReflectionProperty::IS_PUBLIC |
@@ -169,7 +168,7 @@ final readonly class ObjectNormalizer
         }
 
         if (
-            $propertyValue instanceof JsonSerializable
+            is_object($propertyValue)
             && $this->propertyReader->hasJsonPropertyAttributes($attributes)
         ) {
             return true;
@@ -205,7 +204,7 @@ final readonly class ObjectNormalizer
                 is_null($value) => null,
                 is_bool($value), is_scalar($value) => $value,
                 is_array($value) => $this->mapArrayContents($value),
-                $value instanceof JsonSerializable => $this->transferToJsonBuilder($value),
+                is_object($value) => $this->transferToJsonBuilder($value),
                 default => throw new JsonSerializableException('Invalid type in array.'),
             };
         }

--- a/src/Serializer/Normalization/Normalizers/ObjectNormalizer.php
+++ b/src/Serializer/Normalization/Normalizers/ObjectNormalizer.php
@@ -22,7 +22,7 @@ use stdClass;
 use TypeError;
 
 /**
- * Normalize from JsonSerializable to stdClass.
+ * Normalize from object to stdClass.
  */
 final readonly class ObjectNormalizer
 {

--- a/tests/Fixtures/Entities/ClassWithPrivateStringProperty.php
+++ b/tests/Fixtures/Entities/ClassWithPrivateStringProperty.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace SamMcDonald\Json\Tests\Fixtures\Entities;
 
 use SamMcDonald\Json\Serializer\Attributes\JsonProperty;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 
-class ClassWithPrivateStringProperty implements JsonSerializable
+class ClassWithPrivateStringProperty
 {
     public function __construct(
         #[JsonProperty]

--- a/tests/Fixtures/Entities/SimplePropertyClass.php
+++ b/tests/Fixtures/Entities/SimplePropertyClass.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace SamMcDonald\Json\Tests\Fixtures\Entities;
 
 use SamMcDonald\Json\Serializer\Attributes\JsonProperty;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 
-class SimplePropertyClass implements JsonSerializable
+class SimplePropertyClass
 {
     public function __construct(
         #[JsonProperty('userName')]

--- a/tests/Unit/Serializer/Fixtures/BadPropertyNamesSerializable.php
+++ b/tests/Unit/Serializer/Fixtures/BadPropertyNamesSerializable.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace SamMcDonald\Json\Tests\Unit\Serializer\Fixtures;
 
 use SamMcDonald\Json\Serializer\Attributes\JsonProperty;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 
-class BadPropertyNamesSerializable implements JsonSerializable
+
+class BadPropertyNamesSerializable
 {
     #[JsonProperty('user Name')]
     public string $name;

--- a/tests/Unit/Serializer/Fixtures/ClassWithMethodAndConstructor.php
+++ b/tests/Unit/Serializer/Fixtures/ClassWithMethodAndConstructor.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace SamMcDonald\Json\Tests\Unit\Serializer\Fixtures;
 
 use SamMcDonald\Json\Serializer\Attributes\JsonProperty;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 
-class ClassWithMethodAndConstructor implements JsonSerializable
+class ClassWithMethodAndConstructor
 {
     #[JsonProperty('userName', deserialize: true)]
     public string $name;

--- a/tests/Unit/Serializer/Fixtures/ClassWithPublicStringProperty.php
+++ b/tests/Unit/Serializer/Fixtures/ClassWithPublicStringProperty.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace SamMcDonald\Json\Tests\Unit\Serializer\Fixtures;
 
 use SamMcDonald\Json\Serializer\Attributes\JsonProperty;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 
-class ClassWithPublicStringProperty implements JsonSerializable
+class ClassWithPublicStringProperty
 {
     #[JsonProperty]
     public string $name;

--- a/tests/Unit/Serializer/Fixtures/GoodChildObjectSerializable.php
+++ b/tests/Unit/Serializer/Fixtures/GoodChildObjectSerializable.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace SamMcDonald\Json\Tests\Unit\Serializer\Fixtures;
 
 use SamMcDonald\Json\Serializer\Attributes\JsonProperty;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 
-class GoodChildObjectSerializable implements JsonSerializable
+class GoodChildObjectSerializable
 {
     public function __construct(
         #[JsonProperty('childProp1')]

--- a/tests/Unit/Serializer/Fixtures/NestingClasses/Nestable.php
+++ b/tests/Unit/Serializer/Fixtures/NestingClasses/Nestable.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace SamMcDonald\Json\Tests\Unit\Serializer\Fixtures\NestingClasses;
 
 use SamMcDonald\Json\Serializer\Attributes\JsonProperty;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 
-class Nestable implements JsonSerializable
+class Nestable
 {
     #[JsonProperty]
     public int $intVal = 123;

--- a/tests/Unit/Serializer/Fixtures/NoAttributeClasses/SimpleScalaProperties.php
+++ b/tests/Unit/Serializer/Fixtures/NoAttributeClasses/SimpleScalaProperties.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace SamMcDonald\Json\Tests\Unit\Serializer\Fixtures\NoAttributeClasses;
 
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
-
-class SimpleScalaProperties implements JsonSerializable
+class SimpleScalaProperties
 {
     public string $name;
     public int $age;

--- a/tests/Unit/Serializer/Fixtures/ParentClassSerializable.php
+++ b/tests/Unit/Serializer/Fixtures/ParentClassSerializable.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace SamMcDonald\Json\Tests\Unit\Serializer\Fixtures;
 
 use SamMcDonald\Json\Serializer\Attributes\JsonProperty;
-use SamMcDonald\Json\Serializer\Contracts\JsonSerializable;
 
-class ParentClassSerializable implements JsonSerializable
+class ParentClassSerializable
 {
     #[JsonProperty('userName')]
     public string $name;


### PR DESCRIPTION
Previously you had to implement JsonSerializable on a class that you wanted serialized with the JsonProperty.

Now you only need to add the attribute JsonProperty on any object.